### PR TITLE
Fix critical failure description

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -254,7 +254,7 @@
     },
     "blurbs": {
       "base_attributes": "The values below are the base values for your attributes. These will be altered by your backgrounds to generate your actual attribute values. Changes to your attribute values and backgrounds here will update your actual attribute values.",
-      "critical_failure": "Your next attribute test or attack roll should be made with disadvantage!",
+      "critical_failure": "Roll your Doom die immediately",
       "defend_fumble": "Your armour does not protect you from the damage of this attack!",
       "random_generation": "By clicking on the button below you'll randomly generate all details for your character according to the default rules of the system. Note that doing this will overwrite your current character settings - you have been warned!",
       "stories": "Stories dictate your level. The more stories you've survived the higher your will be in level. The list below records the stories you've been part of and what level that makes you. Remember to also select your gifts and attribute bonuses as you attain the appropriate level."

--- a/languages/en.json
+++ b/languages/en.json
@@ -254,7 +254,7 @@
     },
     "blurbs": {
       "base_attributes": "The values below are the base values for your attributes. These will be altered by your backgrounds to generate your actual attribute values. Changes to your attribute values and backgrounds here will update your actual attribute values.",
-      "critical_failure": "Roll your Doom die immediately",
+      "critical_failure": "Roll your Doom die immediately!",
       "defend_fumble": "Your armour does not protect you from the damage of this attack!",
       "random_generation": "By clicking on the button below you'll randomly generate all details for your character according to the default rules of the system. Note that doing this will overwrite your current character settings - you have been warned!",
       "stories": "Stories dictate your level. The more stories you've survived the higher your will be in level. The list below records the stories you've been part of and what level that makes you. Remember to also select your gifts and attribute bonuses as you attain the appropriate level."


### PR DESCRIPTION
According to BSH SRD, 1.2.2. Critical Success and Failure: ...Whatever the roll, a critical failure means you have to roll your Doom die immediately.
There is no mention of a Disadvantage on a critical failure